### PR TITLE
Tab onto memo X and delete using enter key.

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -114,6 +114,8 @@ class Memo {
     this.close.classList.add("close");
     this.move.appendChild(this.close);
     this.close.addEventListener("click", this.deleteMemo.bind(this));
+    this.close.addEventListener("keypress", this.deleteMemoKeyboard.bind(this));
+    this.close.tabIndex = 0;
 
     this.text = document.createElement("textarea");
     this.text.classList.add("text");
@@ -229,6 +231,17 @@ class Memo {
 
     updateLocalStorage();
     this.div.remove();
+  }
+
+  deleteMemoKeyboard(e) {
+    memoList = memoList.filter((memo) => {
+      return memo.id != this.id;
+    });
+
+    if (e.key === "Enter") {
+      updateLocalStorage();
+      this.div.remove();
+    }
   }
 
   moveMemo(e) {


### PR DESCRIPTION
User can use keyboard to tab to X button on each memo, then can press the enter key to close the memo. Memo is removed from the list of available memos.

![notes marker](https://i.imgur.com/g4yvY2z.png)
Left memo's X is selected using tab on keyboard.

![notesmarker](https://i.imgur.com/Biq2R2u.png)
Left memo is closed using enter key. Right memo is unaffected.

When closing a memo using enter key with its X selected, no unrelated memos are closed. User is still able to use enter key when typing within a memo's text content and when selecting note color themes.

This functionality is intended to begin implementation of accessibility features for users with mobility impairments or that use assistive technology.