### PR TITLE
Fix: Memo title overflows text into board.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -47,8 +47,14 @@ main {
   position: absolute;
   left:20px;
   font-size: 20px;
+  background-color: transparent;
   color: var(--border-color);
   width: calc(100% - 20px);
+  height: 30px;
+  resize: none;
+  border: none;
+  word-wrap: break-word;
+  cursor: grab;
 }
 
 .move {

--- a/css/style.css
+++ b/css/style.css
@@ -46,7 +46,8 @@ main {
 .memoTitle{
   position: absolute;
   left:20px;
-  font-size: 20px;
+  font-size: 26px;
+  font-weight: bold;
   background-color: transparent;
   color: var(--border-color);
   width: calc(100% - 20px);

--- a/css/style.css
+++ b/css/style.css
@@ -53,7 +53,9 @@ main {
   height: 30px;
   resize: none;
   border: none;
-  word-wrap: break-word;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   cursor: grab;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -46,8 +46,7 @@ main {
 .memoTitle{
   position: absolute;
   left:20px;
-  font-size: 26px;
-  font-weight: bold;
+  font-size: 30px;
   background-color: transparent;
   color: var(--border-color);
   width: calc(100% - 20px);

--- a/js/app.js
+++ b/js/app.js
@@ -126,12 +126,11 @@ class Memo {
     this.close.addEventListener("keypress", this.deleteMemoKeyboard.bind(this));
     this.close.tabIndex = 0;
 
-    this.heading = document.createElement("h6");
+    this.heading = document.createElement("textarea");
     this.heading.contentEditable = true;
     this.heading.innerHTML = "Untitled";
     this.heading.classList.add("memoTitle");
     this.move.appendChild(this.heading);
-
 
     this.text = document.createElement("textarea");
     this.text.classList.add("text");
@@ -191,7 +190,7 @@ class Memo {
 
     const currentSize = { width: this.size.width, height: this.size.height };
     Object.freeze(currentSize);
-
+    
     movingMemo = false;
     resizingMemo = false;
 


### PR DESCRIPTION
### Problem
When entering a memo title, the user can overflow the text into the board.<br>
![notes marker](https://i.imgur.com/jFMHBhB.png)

### Fix
The intended fix allows the user to enter memo titles of any length but prevents them from overflowing into the board. Extra text stays within the intended line, allowing the user to resize the memo or accept the cut-off title as-is.<br>
![notes marker](https://i.imgur.com/6cWuXke.png)

### Changes

- CSS style changes to white-space: nowrap, overflow: hidden, and text-overflow: ellipsis.
    - This prevents the text from leaving the box.
- General CSS style changes to match visual styling of memo body seen in .text class. 
- Change from previous h6 heading to text area.
    - This matches the project's design standard of using text areas within memo bodies.
    - If project was navigated by a screen reader user, a misplaced h6 absent of any other headings 1-5 would be confusing.

